### PR TITLE
Remove the ~whole argument on compile and route

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
   This makes prefixstr/suffixstr (`**>`/`<**`) redundant, they are removed.
 * The various list combinators now accept a tyregex as separator.
   The old behavior can be recovered by combining with `Tyre.str`.
+* Add the `start` and `stop` combinators.
+* The ~whole argument for compile and route is removed.
+  tyregex don't match the whole string by default anymore.
+  You can use `Tyre.whole_string` or `Tyre.start` and `Tyre.stop` instead.
 
 ## 0.1.1 (09 September 2016)
 * Fix a bug with nested repetitions. Also avoid some copying of the original string.

--- a/examples/ini.ml
+++ b/examples/ini.ml
@@ -37,7 +37,7 @@ let named_section =
   line section_title <&> section
 
 let ini =
-  section <&> Tyre.list named_section
+  Tyre.start *> section <&> Tyre.list named_section <* Tyre.stop
   |> Tyre.conv
     (fun (anon, named) -> { anon ; named })
     (fun { anon ; named } -> (anon, named))

--- a/src/tyre.ml
+++ b/src/tyre.ml
@@ -156,8 +156,11 @@ let some f x = Some (f x)
 let unit s re =
   conv
     (fun _ -> ())
-    (fun _ -> s)
+    (fun () -> s)
     (regex re)
+
+let start = unit "" Re.start
+let stop = unit "" Re.stop
 
 let str s = unit s (Re.str s)
 
@@ -405,16 +408,14 @@ type 'r info =
 
 type 'a re = { info : 'a info ; cre : Re.re }
 
-let compile ?(whole=true) tre =
-  let modf = if whole then Re.whole_string else fun x -> x in
+let compile tre =
   let _, wit, re = build tre in
-  let cre = Re.compile @@ modf re in
+  let cre = Re.compile re in
   { info = One wit ; cre }
 
-let route ?(whole=true) l =
-  let modf = if whole then Re.whole_string else fun x -> x in
+let route l =
   let rel, wl = build_route l in
-  let cre = Re.compile @@ modf @@ Re.alt rel in
+  let cre = Re.compile @@ Re.alt rel in
   { info = Routes wl ; cre }
 
 

--- a/src/tyre.ml
+++ b/src/tyre.ml
@@ -390,7 +390,7 @@ let rec extract_route ~original i subs = function
     (* Invariant: At least one of the regexp of the alternative matches. *)
     assert false
   | WRoute (id, grps, wit, f) :: l ->
-    if Re.marked subs id then
+    if Re.Mark.test subs id then
       let _, v = extract ~original wit i subs in f v
     else
       extract_route ~original (i+grps) subs l

--- a/src/tyre.mli
+++ b/src/tyre.mli
@@ -164,6 +164,9 @@ val separated_list : sep:_ t -> 'a t -> 'a list t
 
     See {!Re} for details on the semantics of those combinators. *)
 
+val start : unit t
+val stop : unit t
+
 val word : 'a t -> 'a t
 val whole_string : 'a t -> 'a t
 val longest : 'a t -> 'a t
@@ -178,9 +181,8 @@ val nest : 'a t -> 'a t
 type 'a re
 (** A compiled typed regular expression. *)
 
-val compile : ?whole:bool -> 'a t -> 'a re
+val compile : 'a t -> 'a re
 (** [compile tyre] is the compiled tyregex representing [tyre].
-    if [whole] is [true] (the default), the whole string is matched.
 *)
 
 type 'a error = [
@@ -219,10 +221,9 @@ type +'a route = Route : 'x t * ('x -> 'a) -> 'a route
 val (-->) : 'x t -> ('x -> 'a) -> 'a route
 (** [tyre --> f] is [Route (tyre, f)]. *)
 
-val route : ?whole:bool -> 'a route list -> 'a re
+val route : 'a route list -> 'a re
 (** [route [ tyre1 --> f1 ; tyre2 --> f2 ]] produces a compiled
     tyregex such that, if [tyre1] matches, [f1] is called, and so on.
-    if [whole] is [true] (the default), the whole string is matched.
 
     The compiled tyregex shoud be used with {!exec}.
 *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -22,7 +22,7 @@ end
 open Tyre
 
 let t' title desc re v s =
-  let cre = Tyre.compile re in
+  let cre = Tyre.(compile (start *> re <* stop)) in
   A.(check (result desc reject))
     (title^" exec") (Tyre.exec cre s) (Result.Ok v) ;
   A.(check bool) (title^" execp") (Tyre.execp cre s) true ;


### PR DESCRIPTION
This made sense when tyre was still in the middle of furl, but not anymore ...