### PR TITLE
Optimise extraction

### DIFF
--- a/src/tyre.ml
+++ b/src/tyre.ml
@@ -98,8 +98,8 @@ let conv_fail to_ from_ x : _ t =
     raise (ConverterFailure exn)
   in
   let to_ x = match to_ x with
-    | Ok x -> x
-    | Error exn -> fail exn
+    | Result.Ok x -> x
+    | Result.Error exn -> fail exn
     | exception exn -> fail exn
   in
   Conv (x, {to_; from_})

--- a/src/tyre.ml
+++ b/src/tyre.ml
@@ -282,7 +282,7 @@ let rec build
       i, Conv (name, w, conv), re
     | Opt e ->
       let i, w, (id, re) = map_3 mark @@ build e in
-      i, Opt (id,i,w), alt [epsilon ; re]
+      i, Opt (id,i,w), opt re
     | Alt (e1,e2) ->
       let i1, w1, (id1, re1) = map_3 mark @@ build e1 in
       let i2, w2, (id2, re2) = map_3 mark @@ build e2 in

--- a/src/tyre.mli
+++ b/src/tyre.mli
@@ -38,19 +38,20 @@ val regex : Re.t -> string t
 
 val conv : ('a -> 'b) -> ('b -> 'a) -> 'a t -> 'b t
 (** [conv ~name to_ from_ tyre] matches the same text as [tyre], but converts back and forth to a different data type.
-*)
-
-val conv_fail : name:string -> ('a -> 'b option) -> ('b -> 'a) -> 'a t -> 'b t
-(** [conv_fail ~name to_ from_ tyre] is similar to [conv to_ from_ tyre] excepts [to_] is allowed to fail by returning [None] or raising an exception. If it does, {!exec} will return [`ConverterFailure (name, s)] with [s] the substring on which the converter was called.
 
 For example, this is the implementation of {!pos_int}:
 
 {[
 let pos_int =
-  Tyre.conv_fail ~name:"pos_int"
-    (fun x -> Some (int_of_string x)) string_of_int
+  Tyre.conv
+    int_of_string string_of_int
     (Tyre.regex (Re.rep1 Re.digit))
 ]}
+*)
+
+val conv_fail :
+  ('a -> ('b, exn) Result.result) -> ('b -> 'a) -> 'a t -> 'b t
+(** [conv_fail to_ from_ tyre] is similar to [conv to_ from_ tyre] excepts [to_] is allowed to fail by returning [Error] or raising an exception. If it does, {!exec} will return [`ConverterFailure exn] where [exn] is the returned exception.
 
 *)
 
@@ -187,7 +188,7 @@ val compile : 'a t -> 'a re
 
 type 'a error = [
   | `NoMatch of 'a re * string
-  | `ConverterFailure of string * string
+  | `ConverterFailure of exn
 ]
 
 val exec : ?pos:int -> ?len:int -> 'a re -> string -> ('a, 'a error) Result.result
@@ -195,7 +196,7 @@ val exec : ?pos:int -> ?len:int -> 'a re -> string -> ('a, 'a error) Result.resu
     the compiled tyregex [ctyre] and returns the extracted value.
 
     Returns [Error (`NoMatch (tyre, s)] if [tyre] doesn't match [s].
-    Returns [Error (`ConverterFailure (name, s))] if the converter named [name] failed while trying to convert the substring [s].
+    Returns [Error (`ConverterFailure exn)] if a converter failed with the exception [exn].
 
     @param pos optional beginning of the string (default 0)
     @param len length of the substring of [str] that can be matched (default to the end of the string)
@@ -255,17 +256,17 @@ val pp_re : Format.formatter -> 'a re -> unit
 (** Internal types *)
 module Internal : sig
 
-  exception ConverterFailure of string * string
+  exception ConverterFailure of exn
 
   type ('a, 'b) conv = {
-    to_ : 'a -> 'b option ;
+    to_ : 'a -> 'b ;
     from_ : 'b -> 'a ;
   }
 
   type 'a raw =
     (* We store a compiled regex to efficiently check string when unparsing. *)
     | Regexp : Re.t * Re.re Lazy.t -> string raw
-    | Conv   : string * 'a raw * ('a, 'b) conv -> 'b raw
+    | Conv   : 'a raw * ('a, 'b) conv -> 'b raw
     | Opt    : 'a raw -> ('a option) raw
     | Alt    : 'a raw * 'b raw -> [`Left of 'a | `Right of 'b] raw
     | Seq    : 'a raw * 'b raw -> ('a * 'b) raw
@@ -279,7 +280,7 @@ module Internal : sig
 
   type _ wit =
     | Lit    : string wit
-    | Conv   : string * 'a wit * ('a, 'b) conv -> 'b wit
+    | Conv   : 'a wit * ('a, 'b) conv -> 'b wit
     | Opt    : Re.markid * int * 'a wit -> 'a option wit
     | Alt    : Re.markid * int * 'a wit * 'b wit
       -> [`Left of 'a | `Right of 'b] wit

--- a/src/tyre.mli
+++ b/src/tyre.mli
@@ -278,7 +278,7 @@ module Internal : sig
   val to_t : 'a raw -> 'a t
 
   type _ wit =
-    | Regexp : Re.t -> string wit
+    | Lit    : string wit
     | Conv   : string * 'a wit * ('a, 'b) conv -> 'b wit
     | Opt    : Re.markid * int * 'a wit -> 'a option wit
     | Alt    : Re.markid * int * 'a wit * 'b wit

--- a/src/tyre.mli
+++ b/src/tyre.mli
@@ -279,16 +279,16 @@ module Internal : sig
   val to_t : 'a raw -> 'a t
 
   type _ wit =
-    | Lit    : string wit
+    | Lit    : int -> string wit
     | Conv   : 'a wit * ('a, 'b) conv -> 'b wit
-    | Opt    : Re.markid * int * 'a wit -> 'a option wit
-    | Alt    : Re.markid * int * 'a wit * 'b wit
+    | Opt    : Re.markid * 'a wit -> 'a option wit
+    | Alt    : Re.markid * 'a wit * 'b wit
       -> [`Left of 'a | `Right of 'b] wit
     | Seq    :
         'a wit * 'b wit -> ('a * 'b) wit
-    | Rep   : 'a wit * Re.re -> 'a gen wit
+    | Rep   : int * 'a wit * Re.re -> 'a gen wit
 
-  val build : 'a raw -> int * 'a wit * Re.t
-  val extract : original:string -> 'a wit -> int -> Re.substrings -> int * 'a
+  val build : int -> 'a raw -> int * 'a wit * Re.t
+  val extract : original:string -> 'a wit -> Re.substrings -> 'a
 
 end

--- a/src/tyre.mli
+++ b/src/tyre.mli
@@ -281,7 +281,7 @@ module Internal : sig
     | Regexp : Re.t -> string wit
     | Conv   : string * 'a wit * ('a, 'b) conv -> 'b wit
     | Opt    : Re.markid * int * 'a wit -> 'a option wit
-    | Alt    : Re.markid * int * 'a wit * Re.markid * 'b wit
+    | Alt    : Re.markid * int * 'a wit * 'b wit
       -> [`Left of 'a | `Right of 'b] wit
     | Seq    :
         'a wit * 'b wit -> ('a * 'b) wit


### PR DESCRIPTION
A lot of little things. Fixes #11 in passing.

Commit https://github.com/Drup/tyre/pull/12/commits/5f2991f0bc03c709c65ecfa0a1a5f9298ab249e8 is a big perf boost (by making group index statically computed).
The downside is that composition of witness is not straighforward now ... which is only a problem for furl anyway. :p