### PR TITLE
Remove conv_fail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,7 @@
 
 * Performance improvements.
 * Fix the behavior of opt (Prefer eating input).
-* Improve/Fix conv_fail:
-  * Use result.
-  * Converter failure returns the raised exception.
+* Remove conv_fail and allow usual converters to fail with an exception.
 
 ## 0.2 (08 October 2016)
 * Rename `<?>` to `<|>`

--- a/src/tyre.ml
+++ b/src/tyre.ml
@@ -87,23 +87,8 @@ let regex x : _ t =
 
 (* Converters
 
-   The implementation here assume converter failures are rare.
-   This way, we avoid allocating an option and using an exception handler in
-   the non-failing case.
+   The exception matching of converters is handled by {!Tyre.exec} directly.
 *)
-exception ConverterFailure of exn
-
-let conv_fail to_ from_ x : _ t =
-  let fail exn =
-    raise (ConverterFailure exn)
-  in
-  let to_ x = match to_ x with
-    | Result.Ok x -> x
-    | Result.Error exn -> fail exn
-    | exception exn -> fail exn
-  in
-  Conv (x, {to_; from_})
-
 let conv to_ from_ x : _ t =
   Conv (x, {to_; from_})
 
@@ -429,7 +414,7 @@ let exec ?pos ?len ({ info ; cre } as tcre) original =
     in
     try
       Result.Ok (f subs)
-    with ConverterFailure exn ->
+    with exn ->
       Result.Error (`ConverterFailure exn)
 
 let execp ?pos ?len {cre ; _ } original =
@@ -488,8 +473,6 @@ module Internal = struct
 
   let to_t x = x
   let from_t x = x
-
-  exception ConverterFailure = ConverterFailure
 
   let build = build
   let extract = extract

--- a/src/tyre.mli
+++ b/src/tyre.mli
@@ -39,6 +39,9 @@ val regex : Re.t -> string t
 val conv : ('a -> 'b) -> ('b -> 'a) -> 'a t -> 'b t
 (** [conv to_ from_ tyre] matches the same text as [tyre], but converts back and forth to a different data type.
 
+    [to_] is allowed to raise an exception [exn].
+    In this case, {!exec} will return [`ConverterFailure exn].
+
 For example, this is the implementation of {!pos_int}:
 
 {[
@@ -47,12 +50,6 @@ let pos_int =
     int_of_string string_of_int
     (Tyre.regex (Re.rep1 Re.digit))
 ]}
-*)
-
-val conv_fail :
-  ('a -> ('b, exn) Result.result) -> ('b -> 'a) -> 'a t -> 'b t
-(** [conv_fail to_ from_ tyre] is similar to [conv to_ from_ tyre] excepts [to_] is allowed to fail by returning [Error] or raising an exception. If it does, {!exec} will return [`ConverterFailure exn] where [exn] is the returned exception.
-
 *)
 
 val opt : 'a t -> 'a option t
@@ -255,8 +252,6 @@ val pp_re : Format.formatter -> 'a re -> unit
 
 (** Internal types *)
 module Internal : sig
-
-  exception ConverterFailure of exn
 
   type ('a, 'b) conv = {
     to_ : 'a -> 'b ;


### PR DESCRIPTION
Instead, regular converters are allowed to raise an exception.