### PR TITLE
add alt_flat function

### DIFF
--- a/src/tyre.ml
+++ b/src/tyre.ml
@@ -81,6 +81,12 @@ let conv to_ from_ x : _ t =
 let seq a b : _ t = Seq (a, b)
 let alt a b : _ t = Alt (a, b)
 
+let alt_flat tyre1 tyre2 =
+  conv
+    (function `Left a -> a | `Right a -> a)
+    (fun a -> `Left a)
+    (alt tyre1 tyre2)
+
 let prefix x a : _ t = Prefix (x, a)
 let suffix a x : _ t = Suffix (a, x)
 let opt a : _ t = Opt a
@@ -92,6 +98,8 @@ module Infix = struct
 
   let ( *>) = prefix
   let (<* ) = suffix
+
+  let ( <||> ) = alt_flat
 
 end
 include Infix

--- a/src/tyre.mli
+++ b/src/tyre.mli
@@ -1,6 +1,6 @@
 (** {1 Typed regular expressions} *)
 
-(** 
+(**
 Tyre is a set of combinators to build type-safe regular expressions, allowing automatic extraction and modification of matched groups.
 
 Tyre is bi-directional: a typed regular expressions can be used both for {{!matching}matching} and {{!eval}evaluation}. Multiple tyregexs can be combined in order to do {{!routing}routing} in similar manner as switches/pattern matching.
@@ -40,7 +40,7 @@ type 'a t
 (** {1 Combinators} *)
 
 val pcre : string -> string t
-(** [pcre s] is a tyregex that matches the PCRE [s] and return the 
+(** [pcre s] is a tyregex that matches the PCRE [s] and return the
     corresponding string.
     Groups in [s] are ignored.
 *)
@@ -72,6 +72,9 @@ val opt : 'a t -> 'a option t
 val alt : 'a t -> 'b t -> [`Left of 'a | `Right of 'b] t
 (** [alt tyreL tyreR] matches either [tyreL] (and will then return [`Left v]) or [tyreR] (and will then return [`Right v]).
 *)
+
+val alt_flat : 'a t -> 'a t -> 'a t
+(** [alt_flat tyreL tyreR] matches either [tyreL] or [tyreR] and return the value of the one that matched. *)
 
 (** {2 Repetitions} *)
 
@@ -125,6 +128,9 @@ module Infix : sig
 
   val (<* ) : 'a t -> _ t -> 'a t
   (** [ t <* ti ] is [suffix t ti]. *)
+
+  val (<||>) : 'a t -> 'a t -> 'a t
+  (** [t <||> t' ] is [alt_flat t t']. *)
 
 end
 


### PR DESCRIPTION
Add an `alt_flat` function, which is just like `alt` but for regexps of the same type.

This PR together with #27  and #28 allow to write the following code : 

```ocaml
let str_nbsp txt = Tyre.(attach ("&nbsp" ^ txt) (str " " *> str txt))

let insert_nbsp_in_string txt =
  Result.get_ok
    Tyre.(replace (compile (str_nbsp ":" <||> str_nbsp ";" <||> str_nbsp "!")) txt)
```

Neat !